### PR TITLE
Add Doc ID list feature to createBatch method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ schema.json
 JavaCaptricityClient.java
 
 doc/
+tests/
 .idea/
 
 *.class

--- a/README.md
+++ b/README.md
@@ -62,14 +62,16 @@ public JSONArray showBatches() throws Exception {...}
 
 ```java
 public JSONObject createBatch(String name) throws Exception {...}
-public JSONObject createBatch(String name, Boolean sorting_enabled, Boolean is_sorting_only) throws Exception {...}
+public JSONObject createBatch(String name, ArrayList<Integer> docIds) throws Exception {...}
+public JSONObject createBatch(String name, Boolean sortingEnabled, Boolean isSortingOnly, ArrayList<Integer> docIds) throws Exception {...}
 ```
 * Creates a Batch in accordance with the given name and properties.
 * Returns a `JSONObject` representing the Batch that was created by the method call.
 * Parameters:
   - `String name` - Provide a name for the Batch you are creating
-  - `Boolean sorting_enabled` \- Set to true to enable sorting for this Batch.  The default value is `true` if not specified.
-  - `Boolean is_sorting_only` \- Set to true if you only want to sort this Batch (as opposed to submit for data extraction).  The default value is `false` if not specified.
+  - `Boolean sortingEnabled` \- Set to true to enable sorting for this Batch.  The default value is `true` if not specified.
+  - `Boolean isSortingOnly` \- Set to true if you only want to sort this Batch (as opposed to submit for data extraction).  The default value is `false` if not specified.
+  - `ArrayList<Integer> docIds` \- Add an ArrayList of integers representing the Document ID's of the templates that you want to use for sorting.  Your account must have sorting enabled for this to work. If sorting is enabled on your account and you do not specify a list of Document ID's, your Batch will be sorted against all active templates in your account.
 
 ```java
 public JSONObject readBatch(int batchID) throws Exception {...}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# java-captools
+# java-captools 1.1
 #### Captricity API client library written in Java
 
 Currently, the Captricity API client library provides methods to accomplish the following:
@@ -25,9 +25,9 @@ From the base of the directory, type
 ant jar
 ```
 
-A jar file named **captricity-1.0.jar** will be generated in the base directory.
+A jar file named **captricity-1.1.jar** will be generated in the base directory.
 
-Copy/move the captricity-1.0.jar file into your classpath.
+Copy/move the captricity-1.1.jar file into your classpath.
 
 and then in your java program, like is done in the example code-- TestCaptricityClient.java,
 
@@ -146,6 +146,3 @@ public JSONArray showDocuments() throws Exception {...}
 [Apache HttpClient 4.4](http://psg.mtu.edu/pub/apache//httpcomponents/httpclient/binary/httpcomponents-client-4.4-bin.zip)
 
 [org.json](http://central.maven.org/maven2/org/json/json/20140107/json-20140107.jar)
-
-### To-Do List...
-- Add methods for more Captricity API functionality

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ public JSONObject createBatch(String name, Boolean sortingEnabled, Boolean isSor
   - `String name` - Provide a name for the Batch you are creating
   - `Boolean sortingEnabled` \- Set to true to enable sorting for this Batch.  The default value is `true` if not specified.
   - `Boolean isSortingOnly` \- Set to true if you only want to sort this Batch (as opposed to submit for data extraction).  The default value is `false` if not specified.
-  - `ArrayList<Integer> docIds` \- Add an ArrayList of integers representing the Document ID's of the templates that you want to use for sorting.  Your account must have sorting enabled for this to work. If sorting is enabled on your account and you do not specify a list of Document ID's, your Batch will be sorted against all active templates in your account.
+  - `ArrayList<Integer> docIds` \- Add an `ArrayList` of integers representing the Document ID's of the templates that you want to use for sorting.  Your account must have sorting enabled for this to work. If sorting is enabled on your account and you do not specify a list of Document ID's, your Batch will be sorted against all active templates in your account.
 
 ```java
 public JSONObject readBatch(int batchID) throws Exception {...}

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
   
   <target name="clean" description="clean up" >
     <delete dir="build" />
-		<delete file="captricity-1.0.jar" />
+		<delete file="captricity-1.1.jar" />
   </target>
 	
   <target name="compile" depends="clean" description="compile the source" >
@@ -12,6 +12,6 @@
   </target>
 
   <target name="jar" depends="compile" description="generate the distribution" >
-    <jar destfile="captricity-1.0.jar" basedir="build/classes" />
+    <jar destfile="captricity-1.1.jar" basedir="build/classes" />
   </target>
 </project>

--- a/examples/TestCaptricityClient.java
+++ b/examples/TestCaptricityClient.java
@@ -77,5 +77,3 @@ public class TestCaptricityClient {
     System.exit(1);
   }
 }
-
-

--- a/src/CaptricityClient.java
+++ b/src/CaptricityClient.java
@@ -1,6 +1,7 @@
 package com.captricity.api;
 
 import java.io.File;
+import java.util.ArrayList;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.StringEntity;
@@ -120,19 +121,28 @@ public class CaptricityClient {
 		return response;
 	}
 	
-	public JSONObject createBatch(String name, Boolean sorting_enabled, Boolean is_sorting_only) throws Exception {
+	public JSONObject createBatch(String name, Boolean sortingEnabled, Boolean isSortingOnly, ArrayList<Integer> docIds) throws Exception {
 		String batchesUri = "https://shreddr.captricity.com/api/v1/batch/";
+    JSONArray docs = new JSONArray(docIds);
 		// assemble payload
 		JSONObject payload = new JSONObject();
 		payload.put("name", name);
-		payload.put("sorting_enabled", sorting_enabled);
-		payload.put("is_sorting_only", is_sorting_only);
+		payload.put("sorting_enabled", sortingEnabled);
+		payload.put("is_sorting_only", isSortingOnly);
+    if ( docs.length() > 0 ) {
+      payload.put("documents", docs);
+    }
 		JSONObject response = makePostCall(batchesUri, payload);
 		return response;
 	}
 	
+  public JSONObject createBatch(String name, ArrayList<Integer> docIds) throws Exception {
+    return createBatch(name, true, false, docIds);
+  }
+  
   public JSONObject createBatch(String name) throws Exception {
-    return createBatch(name, true, false);
+    ArrayList<Integer> docIds = new ArrayList<Integer>();
+    return createBatch(name, true, false, docIds);
   }
   
 	public JSONObject readBatch(int batchID) throws Exception {

--- a/src/CaptricityClient.java
+++ b/src/CaptricityClient.java
@@ -258,8 +258,12 @@ public class CaptricityClient {
           }
         }
         
-      } else {
-        // is_digitized is false
+      } else if ( batch.getString("status").equals("setup") ) {
+        // batch has not been submitted yet...
+        results.append("Batch has not been submitted yet.\n");
+      
+      } else if ( batch.getString("status").equals("processed") ) {
+        // is_digitized is false but it is marked as processed
         
         int rejectCount = 0;
         if ( verboseResults ) {
@@ -298,6 +302,9 @@ public class CaptricityClient {
         } else {
           results.append("Batch has not finished digitization yet.\n");
         }
+      } else {
+        // in an in-between state
+        results.append("Batch is processing.  Please check back later.");
       }
     } else {
       // case of an internal child batch -- don't want to show anything for this type of batch


### PR DESCRIPTION
This code change moves java-captools to version 1.1

This code change makes the following important changes:
- For the createBatch method, it adds the ability to specify an ArrayList of integers representing the ID's of the Documents (templates) against which you want to sort the associated Batch Files.
- Adds more accuracy to the getBatchResults method.
